### PR TITLE
Support servant 0.17

### DIFF
--- a/src/Web/Giphy.hs
+++ b/src/Web/Giphy.hs
@@ -424,7 +424,7 @@ runGiphy'
   -> GiphyConfig
   -> m (Either Servant.ClientError a)
 runGiphy' manager giphy conf =
-  let env = Servant.ClientEnv manager baseUrl Nothing
+  let env = Servant.mkClientEnv manager baseUrl
       runClientM' = flip Servant.runClientM
   in
       liftIO . runClientM' env . Reader.runReaderT giphy $ GiphyContext conf


### PR DESCRIPTION
Use the Servant Client smart constructor to ensure compatibility with the latest `servant` version (`0.17`) on hackage.

This is [currently blocking](https://github.com/commercialhaskell/stackage/issues/5191) inclusion of `servant-0.17` in the latest stackage

